### PR TITLE
rel-v1.2.0 - hero-openmp-examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](http://semver.org).
 
+## v1.2.0 - 2018-09-25
+
+### Added
+- Added top level 'Makefile' for CI and automatic test generation
+
+### Changed
+- On 'make.inc':
+	- Removed useless 'pulp' related cflags
+	- Enable overridable 'run' and 'clean' makefile targets
+
+### Fixed
+- Added 'omp.h' on all the applications after #22 bug fix.
+
 ## v1.1.0 - 2018-09-18
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+DIRECTORIES = $(wildcard */)
+
+.PHONY: test
+test:
+	@$(foreach dir,$(DIRECTORIES), cd $(PWD)/$(dir) &&  make init-target-host clean all run;)

--- a/helloworld/Makefile
+++ b/helloworld/Makefile
@@ -1,4 +1,4 @@
 ############################ OpenMP Sources ############################
 CSRCS = helloworld.c
-CFLAGS= -v 
+CFLAGS= 
 -include $(PWD)/../make.inc

--- a/helloworld/helloworld.c
+++ b/helloworld/helloworld.c
@@ -16,12 +16,12 @@
  * limitations under the License.
  */
 
+#include <omp.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <time.h>
 #include <hero-target.h>
-//#include <omp.h>
 
 struct timespec start, stop;
 double start_ns, stop_ns, exe_time;

--- a/linked-list/Makefile
+++ b/linked-list/Makefile
@@ -1,9 +1,10 @@
 CSRCS = linked-list.c
 CFLAGS= -foffload=riscv32-unknown-elf
--include $(PWD)/../make.inc
 
 prepare::
 ifndef HERO_TARGET_HOST
 $(error HERO_TARGET_HOST is not set)
 endif
 	scp *.txt $(HERO_TARGET_HOST):$(HERO_TARGET_PATH_APPS)/.
+
+-include $(PWD)/../make.inc

--- a/linked-list/linked-list.c
+++ b/linked-list/linked-list.c
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
+#include <omp.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
-//#include <omp.h>
 #include <errno.h>        // for error codes
 #include "bench.h"
 #include <hero-target.h>

--- a/make.inc
+++ b/make.inc
@@ -16,17 +16,12 @@ LD      = $(CROSS_COMPILE)ld
 AS      = $(CROSS_COMPILE)gcc
 OBJCOPY = $(CROSS_COMPILE)objcopy
 OBJDUMP = $(CROSS_COMPILE)objdump
-OPT     =-O2 -g3 -fopenmp
+OPT     =-O3 -g3 -fopenmp
 #
 ############## Includes
-INCDIR        += -include ${PULP_SDK_INSTALL}/hero/hero-z-7045/cl_config.h \
-                    -I${HERO_PULP_INC_DIR}/archi/chips/bigpulp \
-                    -I${HERO_PULP_INC_DIR} \
-                    -I${HERO_SDK_DIR}/libhero-target/inc \
-                    -I../common \
-                    -I.
-COMMON_CFLAGS += ${INCDIR} -v
-CFLAGS        += $(OPT) -Wall -DPLATFORM=${PLATFORM} $(COMMON_CFLAGS) ${EXT_DEF}
+INCDIR        += -I. -I../common -I${HERO_SDK_DIR}/libhero-target/inc
+COMMON_CFLAGS += ${INCDIR}
+CFLAGS        += $(OPT) -Wall $(COMMON_CFLAGS) ${EXT_DEF}
 ASFLAGS       += $(OPT) $(COMMON_CFLAGS)
 LDFLAGS       += -L${HERO_SDK_DIR}/libhero-target/lib -lhero-target
 
@@ -41,14 +36,15 @@ $(EXE): $(OBJS)
 	$(CC) $(CFLAGS) $(OBJS) $(LDFLAGS) -o $@
 
 .PHONY: clean prepare run
-clean:
+clean::
 	rm -rf *.o *~ $(EXE) $(OBJS) offload.bin offload.so
 
-soft-reset-board:
+init-target-host:
 ifndef HERO_TARGET_HOST
 $(error HERO_TARGET_HOST is not set)
 endif
-	ssh -t $(HERO_TARGET_HOST) 'sudo /hsa/bin/boot-hero'
+	ssh -t $(HERO_TARGET_HOST) 'rmmod -f pulp'
+	ssh -t $(HERO_TARGET_HOST) 'insmod $(HERO_TARGET_PATH_DRIVER)/pulp.ko'
 
 prepare:: $(EXE)
 ifndef HERO_TARGET_HOST
@@ -57,7 +53,7 @@ endif
 	ssh $(HERO_TARGET_HOST) "mkdir -p $(HERO_TARGET_PATH_APPS)"
 	scp $(EXE) $(HERO_TARGET_HOST):$(HERO_TARGET_PATH_APPS)/.
 
-run: prepare $(EXE)
+run:: prepare $(EXE)
 ifeq ($(call ifndef_any_of,HERO_TARGET_HOST HERO_TARGET_PATH_APPS HERO_TARGET_PATH_LIB),)
 	ssh -t $(HERO_TARGET_HOST) 'export LD_LIBRARY_PATH='"'$(HERO_TARGET_PATH_LIB)'"'; cd ${HERO_TARGET_PATH_APPS}; ./$(EXE) $(RUN_ARGS)'
 else

--- a/mm-large/mm-large.c
+++ b/mm-large/mm-large.c
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
+#include <omp.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
-//#include <omp.h>
 #include <errno.h>        // for error codes
 #include "bench.h"
 #include <hero-target.h>

--- a/mm-small/mm-small.c
+++ b/mm-small/mm-small.c
@@ -16,11 +16,11 @@
  * limitations under the License.
  */
 
+#include <omp.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
-//#include <omp.h>
 #include <errno.h>        // for error codes
 #include "bench.h"
 #include <hero-target.h>

--- a/sobel-filter/Makefile
+++ b/sobel-filter/Makefile
@@ -22,21 +22,29 @@ IMAGE_NAME   = img
 
 RUN_ARGS=$(IMG_DIR)/$(IMAGE_NAME).rgb $(IMG_DIR)/$(IMAGE_NAME).gray 512x512 -g $(IMG_DIR)/$(IMAGE_NAME)_gray.gray -i $(IMG_DIR)/$(IMAGE_NAME)_h.gray $(IMG_DIR)/$(IMAGE_NAME)_v.gray
 
--include $(PWD)/../make.inc
-
 copyout:
-	convert $(IMG_DIR)/$(IMAGE_NAME).png $(IMG_DIR)/$(IMAGE_NAME).rgb
+	convert $(IMG_DIR)/$(IMAGE_NAME).png $(IMG_DIR)/$(IMAGE_NAME).rgb	
+ifeq ($(call ifndef_any_of,HERO_TARGET_HOST HERO_TARGET_PATH_APPS),)
 	scp -r ${IMG_DIR} $(HERO_TARGET_HOST):${HERO_TARGET_PATH_APPS}
+else
+$(error HERO_TARGET_HOST and/or HERO_TARGET_PATH_APPS is not set)
+endif
 
 copyin:
 	mkdir -p ${IMG_DIR_OUT}
+ifeq ($(call ifndef_any_of,HERO_TARGET_HOST HERO_TARGET_PATH_APPS),)
 	scp -r $(HERO_TARGET_HOST):${HERO_TARGET_PATH_APPS}/${IMG_DIR}/* ${IMG_DIR_OUT}/.
 	convert -size 512x512 -depth 8 $(IMG_DIR_OUT)/$(IMAGE_NAME).gray $(IMG_DIR_OUT)/$(IMAGE_NAME).png
 	convert -size 512x512 -depth 8 $(IMG_DIR_OUT)/$(IMAGE_NAME)_gray.gray $(IMG_DIR_OUT)/$(IMAGE_NAME)_gray.png
 	convert -size 512x512 -depth 8 $(IMG_DIR_OUT)/$(IMAGE_NAME)_h.gray $(IMG_DIR_OUT)/$(IMAGE_NAME)_h.png
 	convert -size 512x512 -depth 8 $(IMG_DIR_OUT)/$(IMAGE_NAME)_v.gray $(IMG_DIR_OUT)/$(IMAGE_NAME)_v.png
+else
+$(error HERO_TARGET_HOST and/or HERO_TARGET_PATH_APPS is not set)
+endif
 
-remove-output:
+clean::
 	rm -rf $(IMG_DIR_OUT)
 
-test: copyout run copyin
+run:: copyout
+
+-include $(PWD)/../make.inc

--- a/sobel-filter/src/main.c
+++ b/sobel-filter/src/main.c
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <omp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
- Changed Makefile(s).
	- Added top level 'Makefile' for CI and automatic test generation
	- Removed useless 'pulp' related cflags
	- Enable overridable 'run' and 'clean' makefile targets
- Added 'omp.h' on all the applications after [#22](https://github.com/pulp-platform/hero-sdk/issues/22) bug fix.
- Update CHANGELOG.md