### PR TITLE
Release v1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 offload.so
 offload.bin
 imgs_out
+__pycache__
+testsuite
+hero-sdk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/), and this project adheres to
 [Semantic Versioning](http://semver.org).
 
+## v1.3.0 - 2018-10-17
+
+Added support for CI testing based on `plptest` framework.
+
+### Added
+- `*/testset.cfg`: add tests configuration file;
+
+### Changed
+- `*/Makefile`: `default.mk` include is now based on absolute path.
+
+
 ## v1.2.1 - 2018-10-2
 
 ### Changed
+
 - Rename `make.inc` in `common/default.mk`.
 
 ## v1.2.0 - 2018-09-25
@@ -23,6 +35,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 ### Fixed
 - Add `omp.h` to all applications after fixing [#22](https://github.com/pulp-platform/hero-sdk/issues/22) in the HERO SDK.
 
+
 ## v1.1.0 - 2018-09-18
 
 ### Added
@@ -34,6 +47,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/), and this 
 - Add license header to all C files.
 - Ensure that remote directory exists during `make install`.
 - `common/bench.h:` Add missing include guard.
+
 
 ## v1.0.0 - 2018-09-14
 

--- a/common/default.mk
+++ b/common/default.mk
@@ -43,10 +43,11 @@ init-target-host:
 ifndef HERO_TARGET_HOST
 $(error HERO_TARGET_HOST is not set)
 endif
+	ssh -t $(HERO_TARGET_HOST) './sourceme.sh'
 	ssh -t $(HERO_TARGET_HOST) 'rmmod -f pulp'
 	ssh -t $(HERO_TARGET_HOST) 'insmod $(HERO_TARGET_PATH_DRIVER)/pulp.ko'
 
-prepare:: $(EXE)
+prepare:: init-target-host $(EXE)
 ifndef HERO_TARGET_HOST
 $(error HERO_TARGET_HOST is not set)
 endif

--- a/helloworld/Makefile
+++ b/helloworld/Makefile
@@ -1,4 +1,5 @@
 ############################ OpenMP Sources ############################
 CSRCS = helloworld.c
 CFLAGS= 
--include $(PWD)/../common/default.mk
+
+-include ${HERO_OMP_EXAMPLES_DIR}/common/default.mk

--- a/linked-list/Makefile
+++ b/linked-list/Makefile
@@ -7,4 +7,4 @@ $(error HERO_TARGET_HOST is not set)
 endif
 	scp *.txt $(HERO_TARGET_HOST):$(HERO_TARGET_PATH_APPS)/.
 
--include $(PWD)/../common/default.mk
+-include ${HERO_OMP_EXAMPLES_DIR}/common/default.mk

--- a/linked-list/testset.cfg
+++ b/linked-list/testset.cfg
@@ -1,0 +1,8 @@
+from plptest import *
+TestConfig = c = {}
+def check_output(config, output):
+   return(output.find("make: *** [run] Error") == -1, None)
+
+c['tests'] = [
+   Test(name = 'linked-list', commands = [ Shell('clean', 'make clean'), Shell('build', 'make all'), Shell('run', 'make run'), Check('check', check_output) ], timeout=1000000),
+]

--- a/mm-large/Makefile
+++ b/mm-large/Makefile
@@ -1,2 +1,3 @@
 CSRCS = mm-large.c
--include $(PWD)/../common/default.mk
+
+-include ${HERO_OMP_EXAMPLES_DIR}/common/default.mk

--- a/mm-large/testset.cfg
+++ b/mm-large/testset.cfg
@@ -1,0 +1,8 @@
+from plptest import *
+TestConfig = c = {}
+def check_output(config, output):
+   return(output.find("make: *** [run] Error") == -1, None)
+
+c['tests'] = [
+   Test(name = 'mm-large', commands = [ Shell('clean', 'make clean'), Shell('build', 'make all'), Shell('run', 'make run'), Check('check', check_output) ], timeout=1000000),
+]

--- a/mm-small/Makefile
+++ b/mm-small/Makefile
@@ -1,2 +1,3 @@
 CSRCS = mm-small.c
--include $(PWD)/../common/default.mk
+
+-include ${HERO_OMP_EXAMPLES_DIR}/common/default.mk

--- a/mm-small/testset.cfg
+++ b/mm-small/testset.cfg
@@ -1,0 +1,8 @@
+from plptest import *
+TestConfig = c = {}
+def check_output(config, output):
+   return(output.find("make: *** [run] Error") == -1, None)
+
+c['tests'] = [
+   Test(name = 'mm-small', commands = [ Shell('clean', 'make clean'), Shell('build', 'make all'), Shell('run', 'make run'), Check('check', check_output) ], timeout=1000000),
+]

--- a/sobel-filter/Makefile
+++ b/sobel-filter/Makefile
@@ -47,4 +47,4 @@ clean::
 
 run:: copyout
 
--include $(PWD)/../common/default.mk
+-include ${HERO_OMP_EXAMPLES_DIR}/common/default.mk

--- a/sobel-filter/testset.cfg
+++ b/sobel-filter/testset.cfg
@@ -1,0 +1,8 @@
+from plptest import *
+TestConfig = c = {}
+def check_output(config, output):
+   return(output.find("make: *** [run] Error") == -1, None)
+
+c['tests'] = [
+   Test(name = 'sobel', commands = [ Shell('conf', 'pwd'), Shell('clean', 'pwd'), Shell('build', 'make all'), Shell('run', 'make run'), Check('check', check_output) ], timeout=1000000),
+]

--- a/testset.cfg
+++ b/testset.cfg
@@ -1,0 +1,15 @@
+from plptest import *
+
+TestConfig = c = {}
+
+tests = Testset(
+  name  = 'hero-openmp-examples',
+  files = [ 
+    'mm-large/testset.cfg',
+    'mm-small/testset.cfg',
+    'sobel-filter/testset.cfg',
+    'linked-list/testset.cfg',    
+  ]
+)
+
+c['testsets'] = [ tests ]


### PR DESCRIPTION
 Added support for CI testing based on `plptest` framework.

 ### Added
 - `*/testset.cfg`: add tests configuration file;

 ### Changed
 - `*/Makefile`: `default.mk` include is now based on absolute path.
 - `common/default.mk`: added `init-target-host` dependency to `prepare` target. It will setup the board in case it is not initialized.